### PR TITLE
Fix csv exporter formatting

### DIFF
--- a/src/services/csv-exporter.test.ts
+++ b/src/services/csv-exporter.test.ts
@@ -23,6 +23,17 @@ const fiscalYearIndex = propertyNames.indexOf('fiscal_year')
 const fiscalQuarterIndex = propertyNames.indexOf('fiscal_quarter')
 const segmentMemberIndex = propertyNames.indexOf('segment_member')
 
+test('format', () => {
+  expect(CsvExporter.format(null)).toEqual('')
+  expect(CsvExporter.format('')).toEqual('')
+  expect(CsvExporter.format('foo')).toEqual('foo')
+  expect(CsvExporter.format(0)).toBe(0)
+  expect(CsvExporter.format(123456789)).toBe(123456789)
+  expect(CsvExporter.format(0.0)).toBe(0.0)
+  expect(CsvExporter.format(123456789.0)).toBe(123456789.0)
+  expect(CsvExporter.format({ foo: 'bar' })).toBe('{"foo":"bar"}')
+})
+
 describe('generateData', () => {
   test('uncached', () => {
     const ticker = '2371'

--- a/src/services/csv-exporter.ts
+++ b/src/services/csv-exporter.ts
@@ -11,10 +11,10 @@ export class CsvExporter {
     //
   }
 
-  static format(
-    value: number | string | object | null
-  ): number | string | null {
-    if (typeof value == 'object') {
+  static format(value: number | string | object | null): number | string {
+    if (value == undefined) {
+      value = ''
+    } else if (typeof value === 'object') {
       value = JSON.stringify(value)
     }
 


### PR DESCRIPTION
CSVの出力時に null値が `JSON.stringify()` によってフォーマットされてしまっていたため、シートの方に `null` という文字列が出てしまっていました。null値の場合は空文字を出力するように修正します。