### PR TITLE
Fix DateParam.parser

### DIFF
--- a/src/custom-functions/bcode.test.ts
+++ b/src/custom-functions/bcode.test.ts
@@ -28,4 +28,5 @@ test('isV3Call', () => {
   expect(isV3Call('', '')).toBeFalsy()
   expect(isV3Call('2020Q1', 'net_sales')).toBeTruthy()
   expect(isV3Call('LYLQ', 'net_sales')).toBeTruthy()
+  expect(isV3Call('2020-09-06', 'market_capital')).toBeTruthy()
 })

--- a/src/fiscal-periods/date-param.test.ts
+++ b/src/fiscal-periods/date-param.test.ts
@@ -17,7 +17,7 @@ test('isLatest', () => {
 })
 
 test('parse', () => {
-  expect(DateParam.parse('2020-09-06')).toEqual(new DateParam(new Date(2020, 9, 6)))
+  expect(DateParam.parse('2020-09-06')).toEqual(new DateParam(new Date('2020-09-06')))
   expect(DateParam.parse('latest')).toEqual(new DateParam('latest'))
   expect(DateParam.parse('Latest')).toEqual(new DateParam('latest'))
   expect(() => DateParam.parse('foo')).toThrow(ParseError)

--- a/src/fiscal-periods/date-param.ts
+++ b/src/fiscal-periods/date-param.ts
@@ -34,9 +34,6 @@ export class DateParam {
       throw new ParseError(`Invalid date format: ${str}`)
     }
 
-    const year = parseInt(matches[1], 10)
-    const month = parseInt(matches[2], 10)
-    const day = parseInt(matches[3], 10)
-    return new DateParam(new Date(year, month, day))
+    return new DateParam(new Date(str))
   }
 }

--- a/src/fiscal-periods/date-range.test.ts
+++ b/src/fiscal-periods/date-range.test.ts
@@ -1,9 +1,9 @@
 import { DateRange } from '~/fiscal-periods/date-range'
 
 test('diff', () => {
-  expect(new DateRange(new Date(2020, 9, 6), new Date(2021, 9, 6)).diff()).toEqual(365)
-  expect(new DateRange(new Date(2020, 9, 6), new Date(2020, 9, 7)).diff()).toEqual(1)
-  expect(new DateRange(new Date(2020, 9, 6), new Date(2020, 9, 6)).diff()).toEqual(0)
-  expect(new DateRange(new Date(2020, 9, 6), new Date(2020, 9, 5)).diff()).toEqual(-1)
-  expect(new DateRange(new Date(2020, 9, 6), new Date(2019, 9, 6)).diff()).toEqual(-366)
+  expect(new DateRange(new Date('2020-09-06'), new Date('2021-09-06')).diff()).toEqual(365)
+  expect(new DateRange(new Date('2020-09-06'), new Date('2020-09-07')).diff()).toEqual(1)
+  expect(new DateRange(new Date('2020-09-06'), new Date('2020-09-06')).diff()).toEqual(0)
+  expect(new DateRange(new Date('2020-09-06'), new Date('2020-09-05')).diff()).toEqual(-1)
+  expect(new DateRange(new Date('2020-09-06'), new Date('2019-09-06')).diff()).toEqual(-366)
 })

--- a/src/fiscal-periods/period-parser.test.ts
+++ b/src/fiscal-periods/period-parser.test.ts
@@ -16,7 +16,7 @@ test('parse', () => {
   expect(PeriodParser.parse('LY-1Q4')).toEqual(new YearQuarterParam(new LyWithOffset(-1), 4))
   expect(PeriodParser.parse('2020LQ-1')).toEqual(new YearQuarterParam(2020, new LqWithOffset(-1)))
   expect(PeriodParser.parse('LY-1LQ-1')).toEqual(new YearQuarterParam(new LyWithOffset(-1), new LqWithOffset(-1)))
-  expect(PeriodParser.parse('2020-09-06')).toEqual(new DateParam(new Date(2020, 9, 6)))
+  expect(PeriodParser.parse('2020-09-06')).toEqual(new DateParam(new Date('2020-09-06')))
   expect(() => PeriodParser.parse('foo')).toThrow(ParseError)
   expect(() => PeriodParser.parse('2020/09/06')).toThrow(ParseError)
   expect(() => PeriodParser.parse('latest')).toThrow(ParseError)


### PR DESCRIPTION
以下のバグを修正します。

- `BCODE(ticker, day, prop)` を実行したときの `day` が意図しない日付に解釈されてしまうバグを修正